### PR TITLE
Build only latest Python and Ruby for space reasons

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -96,7 +96,7 @@ ensure_ruby_build_requirements() {
 ensure_ruby_versions() {
   # You can find out which feature versions are still supported / have
   # been release here: https://www.ruby-lang.org/en/downloads/
-  ruby_versions="$(latest_ruby_version 3.0) $(latest_ruby_version 2.7) $(latest_ruby_version 2.6)"
+  ruby_versions="$(latest_ruby_version 3.0)"
 
   echo "Latest Ruby versions: ${ruby_versions}"
 
@@ -270,7 +270,7 @@ ensure_python_build_requirements() {
 ensure_python_versions() {
   # You can find out which feature versions are still supported / have
   # been release here: https://www.python.org/downloads/
-  python_versions="$(latest_python_version 3.10) $(latest_python_version 3.9) $(latest_python_version 3.8) $(latest_python_version 3.7) $(latest_python_version 3.6)"
+  python_versions="$(latest_python_version 3.10)"
 
   echo "Latest Python versions: ${python_versions}"
 


### PR DESCRIPTION
I'll need to build more in ruby- and python-specific images, I think.