### PR TITLE
Converge on universal cookiecutter upgrader script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,8 @@ cicoverage: report-coverage-to-codecov ## check code coverage, then report to co
 
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
 	bin/cookiecutter_project_upgrader.sh
+	@$(MAKE) post_cookiecutter_sync
+
+post_cookiecutter_sync: ## Ecosystem-specific steps after template sync (empty by default)
+	@:
+

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Run cookiecutter_project_upgrader and the update_from_cookiecutter finish phase.
 # Handles linked git worktrees (gitdir: .git pointer) and worktree-safe git branch ops.
+# Ecosystem-specific post-sync steps belong in Makefile post_cookiecutter_sync.
 
 set -euo pipefail
 
@@ -10,11 +11,35 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
-RBS_HIDDEN=0
-RUBOCOP_MAIN_HIDDEN=0
-RUBOCOP_CWD_HIDDEN=0
+TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
+TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 GIT_WORKTREE_SHIM=0
 REPO_CWD="$(pwd)"
+HIDDEN_BACKUPS=()
+HIDDEN_BACKUP_COUNT=0
+
+hide_for_bake() {
+  local src=$1 bak=$2
+  if [ -f "${src}" ]; then
+    mv "${src}" "${bak}"
+    HIDDEN_BACKUPS+=("${bak}|${src}")
+    HIDDEN_BACKUP_COUNT=$((HIDDEN_BACKUP_COUNT + 1))
+  fi
+}
+
+restore_hidden() {
+  local entry bak dest
+  if [ "${HIDDEN_BACKUP_COUNT}" -eq 0 ]; then
+    return 0
+  fi
+  for entry in "${HIDDEN_BACKUPS[@]}"; do
+    bak="${entry%%|*}"
+    dest="${entry#*|}"
+    [ -f "${bak}" ] && mv "${bak}" "${dest}"
+  done
+  HIDDEN_BACKUPS=()
+  HIDDEN_BACKUP_COUNT=0
+}
 
 cleanup_prepare() {
   if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
@@ -22,55 +47,49 @@ cleanup_prepare() {
     mv "${MAKE_DIR}/git-worktree-pointer" .git
     GIT_WORKTREE_SHIM=0
   fi
-  if [ "${RBS_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rbs_collection.yaml.bak" ]; then
-    mv "${MAKE_DIR}/rbs_collection.yaml.bak" "${MAIN_REPO_ROOT}/rbs_collection.yaml"
-    rm -f "${MAKE_DIR}/rbs_collection_yaml_hidden"
-    RBS_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_MAIN_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-main.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-main.yml.bak" "${MAIN_REPO_ROOT}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_main_hidden"
-    RUBOCOP_MAIN_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_CWD_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-cwd.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-cwd.yml.bak" "${REPO_CWD}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_cwd_hidden"
-    RUBOCOP_CWD_HIDDEN=0
-  fi
-  if [ -d "${GIT_DIR_PATH}/cookiecutter" ]; then
-    rm -rf "${GIT_DIR_PATH}/cookiecutter"
-  fi
+  restore_hidden
+  [ -d "${GIT_DIR_PATH}/cookiecutter" ] && rm -rf "${GIT_DIR_PATH}/cookiecutter"
 }
 
 trap cleanup_prepare EXIT
 
 mkdir -p "${MAKE_DIR}"
 
+CONTEXT_FILE="${MAKE_DIR}/cookiecutter_context.json"
+TEMPLATE_URL=""
 if [ -f docs/cookiecutter_input.json ]; then
   jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
-    > "${MAKE_DIR}/cookiecutter_context.json"
+    > "${CONTEXT_FILE}"
+  TEMPLATE_URL="$(jq -r '._template // empty' "${CONTEXT_FILE}")"
 fi
 
-if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
-  mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
-  touch "${MAKE_DIR}/rbs_collection_yaml_hidden"
-  RBS_HIDDEN=1
-fi
-if [ -f "${MAIN_REPO_ROOT}/.rubocop.yml" ]; then
-  mv "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
-  touch "${MAKE_DIR}/rubocop_main_hidden"
-  RUBOCOP_MAIN_HIDDEN=1
-fi
-# Nested tiers may have their own .rubocop.yml; hide it so RuboCop does not inherit
-# mismatched config while cookiecutter_project_upgrader runs under .git/cookiecutter/
-if [ -f "${REPO_CWD}/.rubocop.yml" ]; then
-  mv "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
-  touch "${MAKE_DIR}/rubocop_cwd_hidden"
-  RUBOCOP_CWD_HIDDEN=1
-fi
+cookiecutter_cache_dir() {
+  local url=$1 name=""
+  if [[ "${url}" =~ github\.com[:/][^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  elif [[ "${url}" =~ ^git@github\.com:[^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+  printf '%s\n' "${HOME}/.cookiecutters/${name}"
+}
 
-if [ -f .make/git-worktree-pointer ] && [ ! -f .git ] && [ ! -L .git ]; then
-  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git is missing; restore manually" >&2
+wipe_template_cache() {
+  local url=$1 cache=""
+  cache="$(cookiecutter_cache_dir "${url}")" || return 0
+  if [ -e "${cache}" ]; then
+    echo "Removing cookiecutter cache ${cache}"
+    rm -rf "${cache}"
+  fi
+}
+
+hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+hide_for_bake "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+hide_for_bake "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
+
+if [ -f .make/git-worktree-pointer ] && [ ! -e .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git missing" >&2
   exit 1
 fi
 
@@ -84,30 +103,36 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
+[ -n "${TEMPLATE_URL}" ] && wipe_template_cache "${TEMPLATE_URL}"
+
 export IN_COOKIECUTTER_PROJECT_UPGRADER=1
-if [ -f "${MAKE_DIR}/cookiecutter_context.json" ]; then
-  cookiecutter_project_upgrader -c "${MAKE_DIR}/cookiecutter_context.json" -p true
-else
-  cookiecutter_project_upgrader
+UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
+[ -f "${CONTEXT_FILE}" ] && UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
+if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
+  if ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
+    >&2 echo "error: upgrader failed and ${TEMPLATE_BRANCH} is missing"
+    exit 1
+  fi
+  echo "cookiecutter_project_upgrader reported no template diff"
 fi
 
 trap - EXIT
 cleanup_prepare
 
-# Finish phase (worktree-safe: no checkout of branches locked in other worktrees)
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-if git symbolic-ref -q "refs/remotes/origin/HEAD" >/dev/null 2>&1; then
+if git symbolic-ref -q refs/remotes/origin/HEAD &>/dev/null; then
   DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
 fi
 
-if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+if ! git diff --quiet -- Makefile 2>/dev/null \
+  || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
   git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
   touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
-git push --no-verify origin cookiecutter-template || true
+git push --no-verify origin "${TEMPLATE_BRANCH}"
+git fetch origin "${DEFAULT_BRANCH}"
 
-git fetch "origin" "${DEFAULT_BRANCH}"
 UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
 git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
 echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
@@ -116,7 +141,7 @@ bin/overcommit --sign
 bin/overcommit --sign pre-commit
 bin/overcommit --sign pre-push
 
-git merge cookiecutter-template || true
+git merge "${TEMPLATE_BRANCH}"
 git checkout --ours Gemfile.lock || true
 
 if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
@@ -124,12 +149,12 @@ if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
   rm -f "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
-bundle update --conservative json rexml || true
-( make build && git add Gemfile.lock ) || true
 bin/overcommit --install || true
 
-echo
-echo "Please resolve any merge conflicts below and push up a PR with:"
-echo
-echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
-echo
+cat <<'EOF'
+
+Please resolve any merge conflicts below and push up a PR with:
+
+   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"
+
+EOF


### PR DESCRIPTION
## Summary
- Universal `bin/cookiecutter_project_upgrader.sh` (matches cookiecutter-cookiecutter).
- `update_from_cookiecutter` calls script then `post_cookiecutter_sync`.

## Notes
Pushed to `upgrader-universal-20260710` because `fix/upgrader-universal-20260710` hit a GitHub directory/file branch conflict.

## Test plan
- [ ] `script/audit_upgrader_convergence.sh` passes for this repo

Made with [Cursor](https://cursor.com)