### PR TITLE
Update from upstream

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ DEPENDENCIES
   punchlist (>= 1.3.1)
 
 CHECKSUMS
-  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
+  bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
   chef-utils (19.3.15) sha256=1c537a9c85b55b6d897de8e8af6b66b017a6dfae2b5e7b25e0bf320637e0b86a
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
@@ -62,4 +62,4 @@ CHECKSUMS
   tomlrb (2.0.4) sha256=262f77947ac3ac9b3366a0a5940ecd238300c553e2e14f22009e2afcd2181b99
 
 BUNDLED WITH
-  4.0.13
+  4.0.15


### PR DESCRIPTION
## Summary
- Bump `Gemfile.lock` Bundler from 4.0.13 to 4.0.15 (cookiecutter-template merge)
- No other boilerplate paths changed vs `origin/main`

## Test plan
- [ ] CI green (build, quality)
- [ ] Spot-check merged boilerplate if non-trivial